### PR TITLE
Add `a:tel` HTML shortcut

### DIFF
--- a/src/expand/expand-full.js
+++ b/src/expand/expand-full.js
@@ -4965,6 +4965,7 @@ var html$1 = {
 	"a": "a[href]",
 	"a:link": "a[href='http://${0}']",
 	"a:mail": "a[href='mailto:${0}']",
+	"a:tel": "a[href='tel:+${0}']",
 	"abbr": "abbr[title]",
 	"acr|acronym": "acronym[title]",
 	"base": "base[href]/",


### PR DESCRIPTION
This adds an expansion for `a href=tel:+` that is strangely missing :) . Hopefully this is the proper repo to add this in. :)

Further details: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Creating_a_phone_link